### PR TITLE
Add line to getListings query to only return active listings

### DIFF
--- a/src/app/actions.js
+++ b/src/app/actions.js
@@ -27,6 +27,7 @@ export async function getListings() {
         owner_role,
         website_url
       FROM listings
+      WHERE active = true
       ORDER BY business_name ASC;
     `;
 


### PR DESCRIPTION
We always want the listing, even if it is expired or needs to be removed for some reason. This change lets us hide listings without deleting them.